### PR TITLE
Add iio configuration for droid 4

### DIFF
--- a/debian/leste-config-droid4.displace
+++ b/debian/leste-config-droid4.displace
@@ -5,6 +5,7 @@
 /etc/modules-load.d/droid4.conf.leste
 /etc/udev/hwdb.d/50-keyboard-modifiers.hwdb.leste
 /lib/udev/rules.d/55-modem.rules.leste
+/lib/udev/rules.d/50-iio-sensors.rules.leste
 /usr/share/X11/xorg.conf.d/40-ts.conf.leste
 /usr/share/X11/xorg.conf.d.pvr/20-modules.conf.leste
 /usr/share/X11/xorg.conf.d.pvr/40-input.conf.leste

--- a/leste-config-droid4/lib/udev/rules.d/50-iio-sensors.rules.leste
+++ b/leste-config-droid4/lib/udev/rules.d/50-iio-sensors.rules.leste
@@ -1,0 +1,2 @@
+SUBSYSTEM=="iio", ENV{OF_NAME}=="isl29030", ENV{PROXIMITY_NEAR_LEVEL}+="200"
+SUBSYSTEM=="iio", ENV{OF_NAME}=="accelerometer", ENV{ACCEL_MOUNT_MATRIX}="-1, 0, 0; 0, -1, 0; 0, 0, 1"


### PR DESCRIPTION
This is required for iio-sensor-proxy and libiio to work correctly