### PR TITLE
Mapphones: switch away from mono mode on exiting internal speaker hifi output

### DIFF
--- a/leste-config-mapphone/usr/share/alsa/ucm2/Mapphone_Audio/HiFi.conf.leste
+++ b/leste-config-mapphone/usr/share/alsa/ucm2/Mapphone_Audio/HiFi.conf.leste
@@ -40,6 +40,7 @@ SectionDevice."Speaker" {
 
 	DisableSequence [
 		cset "name='Speaker Right Playback Route' off"
+		cset "name='HiFi Mono Playback Switch' off"
 	]
 
 	Value {
@@ -59,6 +60,7 @@ SectionDevice."Earpiece" {
 
 	DisableSequence [
 		cset "name='Earpiece Playback Route' off"
+		cset "name='HiFi Mono Playback Switch' off"
 	]
 
 	Value {


### PR DESCRIPTION
This fixes headset sometimes ending up in mono mode