### PR TITLE
Earpiece volume too loud fix

### DIFF
--- a/leste-config-pinephone/usr/share/alsa/ucm2/simple-card/VoiceCall.conf.leste
+++ b/leste-config-pinephone/usr/share/alsa/ucm2/simple-card/VoiceCall.conf.leste
@@ -74,7 +74,7 @@ SectionDevice."Earpiece" {
 	EnableSequence [
 		cset "name='AIF1 DA0 Stereo Playback Route' Mix Mono"
 		cset "name='Earpiece Playback Switch' on"
-		cset "name='Earpiece Playback Volume' 100%"
+		cset "name='Earpiece Playback Volume' 60%"
 	]
 
 	DisableSequence [


### PR DESCRIPTION
Tested by user teyrok from TMO
Tested with Pinephone hardware revision 1.2
Earpiece default volume at 100% is too much and not usable. Decreasing it to 60% seems better for user experience.