### PR TITLE
N900: add custom faster transitions.ini file

### DIFF
--- a/leste-config-n900/usr/share/hildon-desktop/transitions.ini.leste
+++ b/leste-config-n900/usr/share/hildon-desktop/transitions.ini.leste
@@ -1,0 +1,249 @@
+# This file contains timings and values for transitions in hildon-desktop
+# duration = time in milliseconds
+# zoom = amount to zoom out the background. 1 = none, 0.5 = zoom to half size
+# radius = radius of blur (this is actually the number of blur iterations,
+#          so the bigger the number the longer it takes)
+# saturation = the amount of colour left in the background (0 = grey, 1 = normal)
+# brightness = brightness of the background (0 = black, 1 = normal)          
+
+[blur]
+turbo = 0
+#duration = 50
+duration = 0
+
+# Zoom out of the task navigator before it fades out
+# -- zoom: how much to scale the switcher when going to launcher
+#	   (the second layer of the launcher would scale it twice
+#	    as much but the switcher is hidden by that time currently)
+# -- zoom_for_home: how much to scale the switcher when leaving for home
+# -- zoom_duration: the number of miliseconds to spend on zooming
+#		    a thumbnail
+# -- fly_duration: how long should it take for the thumbnails to rearrange
+# -- notifade_in/out: time to fade the notifications
+# 
+[task_nav]
+#zoom = 0.85
+#zoom_for_home = 1.4
+#zoom_duration = 50
+#fly_duration = 50
+#notifade_in = 150
+#notifade_out = 150
+zoom = 0
+zoom_for_home = 0
+zoom_duration = 0
+fly_duration = 0
+notifade_in = 0
+notifade_out = 0
+tile_font = Nokia Sans 15
+
+# Blurring of the home view
+# -- radius: amount of iterations of blur filter to perform when not zoooming
+#            eg. for dialogs
+# -- radius_more: amount of iterations of blur filter to perform when zooming
+#                 eg. for launcher/task navigator
+# -- saturation: saturation of the background when blurred
+# -- brightness: brightness of the background when blurred
+# -- zoom: Basic amount to scale the home view by (gets multiplied by how many 
+#          'levels' deep the UI is - eg. launcher is one level, launcher submenu
+#          is another)
+# -- zoom_applets: Amount to scale applets by when zooming out
+# -- zoom_on_press: set to 1 to include a zoom effect when the screen is pressed
+# -- parallax: Amount of parallax between desktop and widget layers when panning
+[home]
+#radius = 12
+#radius_more = 16
+#saturation = 0.8
+#brightness = 0.4
+#zoom = 0.93
+#zoom_applets = 0.85
+radius = 0
+radius_more = 0
+saturation = 1
+brightness = 1
+zoom = 0
+zoom_applets = 0
+zoom_on_press = 0
+parallax = 1.3
+
+# These control the deceleration of the launcher pages.  When panning freely
+# (decelerating) the velocity of the launcher page is adjusted by this much.
+# strong_deceleration_rate is effective in the bouncing zones.  Uncomment if
+# you want faster panning.
+[launcher]
+#deceleration_rate = 0.98
+#strong_deceleration_rate = 0.7
+
+# The glow effect around launcher buttons
+[launcher_glow]
+#duration_in = 100
+#duration_out = 200
+duration_in = 0
+duration_out = 0
+radius = 10
+brightness = 0.75
+
+# The items below are for the transitions that are applied
+# to a 'page' of launcher icons
+# -- duration: time in ms
+# -- depth: amount to move icons backwards and forwards (with perspective)
+#           this is pretty much how big or small the icons get     
+# -- sequenced: for in and in_sub, whether icons swoop nicely in (1)
+#               or whether they just all zoom in as one (0)
+# -- keyframes: A list of values that are linearly interpolated between 
+#               to produce the movement of the launcher tiles. There can 
+#               be any number of values as long as there are 2 or more. 
+#               <1 means nearer the viewer, >1 means further away
+# -- keyframes_label: The values used for fading in the labels. 0=transparent
+#                     1=opaque
+# -- keyframes_icon: The values used for fading in the icons. 0=transparent
+#                     1=opaque
+# Launcher top layer first appearing
+[launcher_in]
+duration = 0
+sequenced = 0
+depth = 225
+keyframes = 0,0.17,0.39,0.65,0.87,1.13,1.26,1.22,1.17,1.13,1.09,1.04,1,1,1,1,1,1,1,1,1
+keyframes_icon = 0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1,1,1,1,1,1,1,1,1,1,1
+keyframes_label = 0,0,0,0,0,0,0,0,0,0,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1
+
+# Launcher top layer disappearing
+[launcher_out]
+duration = 0
+depth = 150
+
+# launcher top layer disappearing when a layer in front
+[launcher_out_back]
+duration = 0
+depth = 0
+
+# launch animation
+# duration_out - amount of time to take when fading the launcher out and application in
+# delay - the amount of time to wait after the window has appeared before we fade out
+#         (this time is *included* in duration_out, so it must be <= duration_out)  
+[launcher_launch]
+#duration = 400
+#delay = 500
+#duration_out = 1400
+duration = 0
+delay = 500
+duration_out = 0
+depth = 100
+
+# sub-menu appearing
+[launcher_in_sub]
+duration = 0
+sequenced = 0
+depth = 200
+keyframes = 0,0.17,0.39,0.65,0.87,1.13,1.26,1.22,1.17,1.13,1.09,1.04,1,1,1,1,1,1,1,1,1
+keyframes_icon = 0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1,1,1,1,1,1,1,1,1,1,1
+keyframes_label = 0,0,0,0,0,0,0,0,0,0,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1
+
+# sub-menu disappearing
+[launcher_out_sub]
+duration = 0
+depth = 150
+
+# main disappearing when sub-menu appears
+[launcher_back]
+duration = 0
+depth = 150
+
+# main appearing when sub-menu disappears
+[launcher_forward]
+duration = 0
+depth = 100
+
+# Screen rotation transition
+# duration_in = time for rotation before blanking
+# duration_out = time for rotation after blanking
+# damage_timeout = in the rotation transition, the amount of milliseconds to
+#                  leave after we get a damage event before we transition back
+#                  from blanking.
+# damage_timeout_max = maximum amount of time we may wait if we keep getting
+#                      damage events.
+# angle = rotation angle for each transition, in degrees. Ideally this is set
+#         so that the screen looks like it keeps turning at the same speed 
+#         during blanking. 0 is none, 90 degrees is side-on
+[rotate]
+duration_in = 200
+duration_out = 200
+damage_timeout = 0
+damage_timeout_plus = 0
+damage_timeout_max = 0
+angle = 45
+# changed from 100 in order to reduce jerkiness of transition (also changed the 
+# fade-out so it doesn't fade to black completely)
+
+# App close transition
+[app_close]
+#duration = 250
+duration = 0
+
+# Popup for dialogs and status menu
+[popup]
+duration_in = 0
+duration_out = 0
+
+# Fade in for banners
+# _alpha specifies the final transparency of various things
+# currently only banner_note and info_note are supported
+[fade]
+duration_in = 0
+duration_out = 0
+banner_note_alpha = 0.85
+info_note_alpha = 0.85
+
+# Transition for notification previews
+[notification]
+is_cool = 0
+duration_in = 0
+duration_out = 0
+
+# Sliding subview window transition
+[subview]
+duration_in = 0
+duration_out = 0
+
+[loading_timeout]
+# This is multiplied by the load average to find the timeout
+# in seconds. before "Unable to load" is displayed.  There is
+# a minimum of 10s.
+load_average_factor = 7.5
+
+# Edit mode configuration
+[edit_mode]
+snap_grid_size = 4
+# Set to 0 if snap to grid should be only happen when widget is released
+snap_to_grid_while_move = 1
+
+##
+# Special tweaks (a restart might be required)
+##
+[thp_tweaks]
+# Blurless desaturation (0 = default, 1 = MeeGo/Symbian-style)
+blurless = 0
+# saturation value for blurless (0 = no color, 1 = full color)
+blurless_saturation = 0
+# [home] brightness, is used for the brightness
+
+# Bigger task switcher (0 = default, 1 = single column, 2 = two columns)
+taskswitcher = 0
+
+# Rotation around the Z axis (0 = rotate around X/Y, 1 = rotate around Z)
+zaxisrotation = 0
+
+# Forced app auto-rotation (0 = default, 1 = auto-rotate every app)
+forcerotation = 0
+
+# Popup feedback using the "tactile" utility (0 = disabled, 1 = enabled)
+# You need to install "tactile" from the maemo.org repositories for this
+tactilepopups = 0
+
+# Lock application window in landscape mode
+blacklist = mediaplayer osso-xterm worldclock image-viewer camera-ui Calendar
+
+# Thumbnails desaturation in tasknav
+thumb_desaturation = 0
+
+# Enables portrait mode for a given application
+whitelist = osso-backup ossofilemanager osso_notes


### PR DESCRIPTION
All zoom effects and animations are now deactivated (they were not really visible anyway). This transitions.ini file is based on well known tweaks on Fremantle. No effect on stability (even better, specially without overclock). GTK and Qt5 UI's are more responsive.