### PR TITLE
leste-config-n900: change cmt_speech group

### DIFF
--- a/leste-config-n900/lib/udev/rules.d/10-nokia-modem.rules.leste
+++ b/leste-config-n900/lib/udev/rules.d/10-nokia-modem.rules.leste
@@ -6,4 +6,4 @@ SUBSYSTEMS=="hsi", ENV{OFONO_DRIVER}="n900", ENV{OFONO_ISI_ADDRESS}="108"
 KERNEL=="phonet*", ENV{OFONO_DRIVER}="n900", ENV{OFONO_ISI_ADDRESS}="108"
 
 # Default is 0600, root:root, let's make it a bit more usable
-KERNEL=="cmt_speech", MODE:="0660", OWNER:="root", GROUP:="pulse"
+KERNEL=="cmt_speech", MODE:="0660", OWNER:="root", GROUP:="audio"


### PR DESCRIPTION
cmt_pulse works best as user when /dev/cmt_speech is owned by the audio group.