### PR TITLE
modprobe.d: blacklist unneeded power_supply drivers

### DIFF
--- a/leste-config-n900/etc/modprobe.d/blacklist-supply.conf.leste
+++ b/leste-config-n900/etc/modprobe.d/blacklist-supply.conf.leste
@@ -1,0 +1,4 @@
+blacklist rx51-battery
+blacklist twl4030_ac
+blacklist twl4030_usb
+blacklist bq27000-battery


### PR DESCRIPTION
Most of the listed drivers should ideally be dropped from the kernel config, but we can also can just blacklist them as they are not needed on the N900, in case we want to keep the diff against omap2plus_defconfig small.

rx51-battery is useful to enable and keep in the config because it is able to determine the battery's design capacity, but for the sake of upower, it can be blacklisted in general and loaded manually by users who want to use its features.