### PR TITLE
Update vfs_cache_pressure and swappiness

### DIFF
--- a/leste-config-n900/etc/sysctl.d/n900-perf.conf.leste
+++ b/leste-config-n900/etc/sysctl.d/n900-perf.conf.leste
@@ -1,5 +1,5 @@
-vm.swappiness=30
+vm.swappiness=60
 vm.page-cluster=8
-vm.vfs_cache_pressure=200
+vm.vfs_cache_pressure=50
 vm.dirty_ratio=5
 vm.dirty_background_ratio=2


### PR DESCRIPTION
Swappiness and vfs_cache_pressure values seem too agressive for slow SD cards: New values improve responsiveness and launch time in particular for Qt5 apps.