### PR TITLE
Enable remixing by default

### DIFF
--- a/leste-config-n900/etc/pulse/daemon.conf.leste
+++ b/leste-config-n900/etc/pulse/daemon.conf.leste
@@ -50,10 +50,10 @@
 ; log-time = no
 ; log-backtrace = 0
 
-resample-method = speex-fixed-2
+resample-method = speex-float-1
 ; avoid-resampling = false
-; enable-remixing = yes
-; remixing-use-all-sink-channels = yes
+enable-remixing = yes
+remixing-use-all-sink-channels = yes
 ; remixing-produce-lfe = no
 ; remixing-consume-lfe = no
 ; lfe-crossover-freq = 0


### PR DESCRIPTION
This commit avoids severe slowdown or PA crash, when several sounds are supposed to play at the same time, specially if the phone is ringing while playing audio/video file.

Note: with next PA version ( >14), it should be possible to use module-match to automatically mute other apps and only keep phone/voip sound during calls.

Speex-float-1 works fine now on n900.