### PR TITLE
n900: modprobe.d: blacklist-supply: Use correct module names

### DIFF
--- a/leste-config-n900/etc/modprobe.d/blacklist-supply.conf.leste
+++ b/leste-config-n900/etc/modprobe.d/blacklist-supply.conf.leste
@@ -1,4 +1,3 @@
-blacklist rx51-battery
-blacklist twl4030_ac
-blacklist twl4030_usb
-blacklist bq27000-battery
+blacklist rx51_battery
+blacklist bq27xxx_battery_hdq
+blacklist twl4030_charger


### PR DESCRIPTION
41ea0962170f ("modprobe.d: blacklist unneeded power_supply drivers") intended to blacklist unneeded supply drivers on the N900. However, some names turned out to be wrong, since the names in /sys/class/power_supply were used. Use corrected module names.

Fixes: 41ea0962170f ("modprobe.d: blacklist unneeded power_supply drivers")